### PR TITLE
Mark getHeadersFromServer as static

### DIFF
--- a/src/ServerRequestCreator.php
+++ b/src/ServerRequestCreator.php
@@ -88,7 +88,7 @@ class ServerRequestCreator implements ServerRequestCreatorInterface
     /**
      * Implementation from Zend\Diactoros\marshalHeadersFromSapi().
      */
-    public function getHeadersFromServer(array $server): array
+    public static function getHeadersFromServer(array $server): array
     {
         $headers = [];
         foreach ($server as $key => $value) {

--- a/src/ServerRequestCreatorInterface.php
+++ b/src/ServerRequestCreatorInterface.php
@@ -48,5 +48,5 @@ interface ServerRequestCreatorInterface
      *
      * @return array
      */
-    public function getHeadersFromServer(array $server): array;
+    public static function getHeadersFromServer(array $server): array;
 }

--- a/tests/ServerRequestCreatorTest.php
+++ b/tests/ServerRequestCreatorTest.php
@@ -499,7 +499,7 @@ class ServerRequestCreatorTest extends TestCase
             'content-length' => 'UNSPECIFIED',
         ];
 
-        $this->assertSame($expected, $this->creator->getHeadersFromServer($server));
+        $this->assertSame($expected, ServerRequestCreator::getHeadersFromServer($server));
     }
 
     /**
@@ -519,6 +519,6 @@ class ServerRequestCreatorTest extends TestCase
             'x-foo-bar' => 'nonprefixed',
         ];
 
-        $this->assertEquals($expected, $this->creator->getHeadersFromServer($server));
+        $this->assertEquals($expected, ServerRequestCreator::getHeadersFromServer($server));
     }
 }


### PR DESCRIPTION
PR as discussed in #11.

Making this method static makes sense, as people might want to use it as polyfill for the Apache only `getallheaders`.