### PR TITLE
Fallback to an empty Stream in UploadedFile if no Stream could be created from a file

### DIFF
--- a/src/ServerRequestCreator.php
+++ b/src/ServerRequestCreator.php
@@ -190,8 +190,14 @@ final class ServerRequestCreator implements ServerRequestCreatorInterface
             return $this->normalizeNestedFileSpec($value);
         }
 
+        try {
+            $stream = $this->streamFactory->createStreamFromFile($value['tmp_name']);
+        } catch (\RuntimeException $e) {
+            $stream = $this->streamFactory->createStream();
+        }
+
         return $this->uploadedFileFactory->createUploadedFile(
-            $this->streamFactory->createStreamFromFile($value['tmp_name']),
+            $stream,
             (int) $value['size'],
             (int) $value['error'],
             $value['name'],


### PR DESCRIPTION
It is possible for `StreamFactoryInterface::createStreamFromFile` to fail and throw a `RuntimeException`. One such case may occur when the file upload has failed and the `tmp_name` is empty.

`ServerRequestCreator` should not exit on such an error, and should be able to create a list of `UploadedFile` instances included those with errors. When `StreamFactoryInterface::createStreamFromFile` fails, use an empty `Stream` instead.

This hopefully fixes #20. At least as far as this package is concerned.

Would love it if you could especially review the unit test, @Nyholm. This was a bit of a head scratcher. I’m using a mock `StreamFactoryInterface` so I can make `createStreamFromFile` always throw…