### PR TITLE
Add missing support for Host-header with port-number

### DIFF
--- a/src/ServerRequestCreator.php
+++ b/src/ServerRequestCreator.php
@@ -248,14 +248,18 @@ final class ServerRequestCreator implements ServerRequestCreatorInterface
             $uri = $uri->withScheme('on' === $server['HTTPS'] ? 'https' : 'http');
         }
 
-        if (isset($server['HTTP_HOST'])) {
-            $uri = $uri->withHost($server['HTTP_HOST']);
-        } elseif (isset($server['SERVER_NAME'])) {
-            $uri = $uri->withHost($server['SERVER_NAME']);
-        }
-
         if (isset($server['SERVER_PORT'])) {
             $uri = $uri->withPort($server['SERVER_PORT']);
+        }
+
+        if (isset($server['HTTP_HOST'])) {
+            if (preg_match('/^([^\:]+)\:(\d+)$/', $server['HTTP_HOST'], $matches) === 1) {
+                $uri = $uri->withHost($matches[1])->withPort($matches[2]);
+            } else {
+                $uri = $uri->withHost($server['HTTP_HOST']);
+            }
+        } elseif (isset($server['SERVER_NAME'])) {
+            $uri = $uri->withHost($server['SERVER_NAME']);
         }
 
         if (isset($server['REQUEST_URI'])) {

--- a/src/ServerRequestCreator.php
+++ b/src/ServerRequestCreator.php
@@ -51,7 +51,7 @@ final class ServerRequestCreator implements ServerRequestCreatorInterface
 
         $headers = \function_exists('getallheaders') ? getallheaders() : static::getHeadersFromServer($_SERVER);
 
-        return $this->fromArrays($server, $headers, $_COOKIE, $_GET, $_POST, $_FILES, fopen('php://input', 'r') ?: null);
+        return $this->fromArrays($server, $headers, $_COOKIE, $_GET, $_POST, $_FILES, \fopen('php://input', 'r') ?: null);
     }
 
     /**
@@ -253,7 +253,7 @@ final class ServerRequestCreator implements ServerRequestCreatorInterface
         }
 
         if (isset($server['HTTP_HOST'])) {
-            if (preg_match('/^(.+)\:(\d+)$/', $server['HTTP_HOST'], $matches) === 1) {
+            if (1 === \preg_match('/^(.+)\:(\d+)$/', $server['HTTP_HOST'], $matches)) {
                 $uri = $uri->withHost($matches[1])->withPort($matches[2]);
             } else {
                 $uri = $uri->withHost($server['HTTP_HOST']);

--- a/src/ServerRequestCreator.php
+++ b/src/ServerRequestCreator.php
@@ -253,7 +253,7 @@ final class ServerRequestCreator implements ServerRequestCreatorInterface
         }
 
         if (isset($server['HTTP_HOST'])) {
-            if (preg_match('/^([^\:]+)\:(\d+)$/', $server['HTTP_HOST'], $matches) === 1) {
+            if (preg_match('/^(.+)\:(\d+)$/', $server['HTTP_HOST'], $matches) === 1) {
                 $uri = $uri->withHost($matches[1])->withPort($matches[2]);
             } else {
                 $uri = $uri->withHost($server['HTTP_HOST']);

--- a/tests/ServerRequestCreatorTest.php
+++ b/tests/ServerRequestCreatorTest.php
@@ -458,7 +458,7 @@ class ServerRequestCreatorTest extends TestCase
             ],
             'Different port' => [
                 'http://www.blakesimpson.co.uk:8324/blog/article.php?id=10&user=foo',
-                array_merge($server, ['SERVER_PORT' => '8324']),
+                array_merge($server, ['SERVER_PORT' => '8324', 'HTTP_HOST' => $server['HTTP_HOST'].':8324']),
             ],
             'Empty server variable' => [
                 '',

--- a/tests/ServerRequestCreatorTest.php
+++ b/tests/ServerRequestCreatorTest.php
@@ -460,6 +460,18 @@ class ServerRequestCreatorTest extends TestCase
                 'http://www.blakesimpson.co.uk:8324/blog/article.php?id=10&user=foo',
                 array_merge($server, ['SERVER_PORT' => '8324', 'HTTP_HOST' => $server['HTTP_HOST'].':8324']),
             ],
+            'IPv4' => [
+                'http://127.0.0.1/blog/article.php?id=10&user=foo',
+                array_merge($server, ['SERVER_PORT' => '80', 'HTTP_HOST' => '127.0.0.1']),
+            ],
+            'IPv4 with port' => [
+                'http://127.0.0.1:8324/blog/article.php?id=10&user=foo',
+                array_merge($server, ['SERVER_PORT' => '8324', 'HTTP_HOST' => '127.0.0.1:8324']),
+            ],
+            'IPv6 with port' => [
+                'http://::1:8324/blog/article.php?id=10&user=foo',
+                array_merge($server, ['SERVER_PORT' => '8324', 'HTTP_HOST' => '::1:8324']),
+            ],
             'Empty server variable' => [
                 '',
                 [],


### PR DESCRIPTION
The `Host` header, according to [RFC2616 section 14.23](https://tools.ietf.org/html/rfc2616#section-14.23), may contain a port-number.

The current implementation doesn't handle this, and effectively ends up producing an `UriInterface` instance that returns a host-name string with the port-number inside it.

PSR-7 actually isn't explicit on this point, but I'd have to assume that, since there's a `getPort()` method for obtaining the port-number, then `getHost()` isn't supposed to also return the port-number, just the host-name.

This PR includes a regression-test (which did fail) and a fix.