### PR TITLE
Do not imply having parsed the request body

### DIFF
--- a/src/ServerRequestCreator.php
+++ b/src/ServerRequestCreator.php
@@ -62,6 +62,7 @@ final class ServerRequestCreator implements ServerRequestCreatorInterface
                     ['application/x-www-form-urlencoded', 'multipart/form-data']
                 )) {
                     $post = $_POST;
+
                     break;
                 }
             }

--- a/src/ServerRequestCreator.php
+++ b/src/ServerRequestCreator.php
@@ -52,8 +52,19 @@ final class ServerRequestCreator implements ServerRequestCreatorInterface
         $headers = \function_exists('getallheaders') ? getallheaders() : static::getHeadersFromServer($_SERVER);
 
         $post = null;
-        if ('POST' === $this->getMethodFromEnv($server) && \in_array($headers['content-type'], ['application/x-www-form-urlencoded', 'multipart/form-data'])) {
-            $post = $_POST;
+        if ('POST' === $this->getMethodFromEnv($server)) {
+            foreach ($headers as $headerName => $headerValue) {
+                if ('content-type' !== \strtolower($headerName)) {
+                    continue;
+                }
+                if (\in_array(
+                    \strtolower(\trim(\explode(';', $headerValue, 2)[0])),
+                    ['application/x-www-form-urlencoded', 'multipart/form-data']
+                )) {
+                    $post = $_POST;
+                    break;
+                }
+            }
         }
 
         return $this->fromArrays($server, $headers, $_COOKIE, $_GET, $post, $_FILES, \fopen('php://input', 'r') ?: null);

--- a/src/ServerRequestCreator.php
+++ b/src/ServerRequestCreator.php
@@ -51,13 +51,18 @@ final class ServerRequestCreator implements ServerRequestCreatorInterface
 
         $headers = \function_exists('getallheaders') ? getallheaders() : static::getHeadersFromServer($_SERVER);
 
-        return $this->fromArrays($server, $headers, $_COOKIE, $_GET, $_POST, $_FILES, \fopen('php://input', 'r') ?: null);
+        $post = null;
+        if ('POST' === $this->getMethodFromEnv($server) && \in_array($headers['content-type'], ['application/x-www-form-urlencoded', 'multipart/form-data'])) {
+            $post = $_POST;
+        }
+
+        return $this->fromArrays($server, $headers, $_COOKIE, $_GET, $post, $_FILES, \fopen('php://input', 'r') ?: null);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function fromArrays(array $server, array $headers = [], array $cookie = [], array $get = [], array $post = [], array $files = [], $body = null): ServerRequestInterface
+    public function fromArrays(array $server, array $headers = [], array $cookie = [], array $get = [], array $post = null, array $files = [], $body = null): ServerRequestInterface
     {
         $method = $this->getMethodFromEnv($server);
         $uri = $this->getUriFromEnvWithHTTP($server);

--- a/src/ServerRequestCreatorInterface.php
+++ b/src/ServerRequestCreatorInterface.php
@@ -31,7 +31,7 @@ interface ServerRequestCreatorInterface
      * @param array                                $headers typically the output of getallheaders() or similar structure
      * @param array                                $cookie  typically $_COOKIE or similar structure
      * @param array                                $get     typically $_GET or similar structure
-     * @param array                                $post    typically $_POST or similar structure
+     * @param array|null                           $post    typically $_POST or similar structure, represents parsed request body
      * @param array                                $files   typically $_FILES or similar structure
      * @param StreamInterface|resource|string|null $body    Typically stdIn
      *
@@ -42,7 +42,7 @@ interface ServerRequestCreatorInterface
         array $headers = [],
         array $cookie = [],
         array $get = [],
-        array $post = [],
+        array $post = null,
         array $files = [],
         $body = null
     ): ServerRequestInterface;


### PR DESCRIPTION
Strictly follow the PSR-7 guidance where `$_POST` is used for a request’s parsed body only for very specific requests. All other requests should result in a null value and leave other parsing up to application logic.

The current practice of putting an empty array in may imply we have done parsing and found an empty request body. See also Nyholm/psr7#100.