### PR TITLE
Update the URI creation.

### DIFF
--- a/src/ServerRequestCreator.php
+++ b/src/ServerRequestCreator.php
@@ -242,28 +242,16 @@ final class ServerRequestCreator implements ServerRequestCreatorInterface
     {
         $uri = $this->uriFactory->createUri('');
 
-        if (isset($server['HTTP_X_FORWARDED_PROTO'])) {
-            $uri = $uri->withScheme($server['HTTP_X_FORWARDED_PROTO']);
-        } else {
-            if (isset($server['REQUEST_SCHEME'])) {
-                $uri = $uri->withScheme($server['REQUEST_SCHEME']);
-            } elseif (isset($server['HTTPS'])) {
-                $uri = $uri->withScheme('on' === $server['HTTPS'] ? 'https' : 'http');
-            }
-
-            if (isset($server['SERVER_PORT'])) {
-                $uri = $uri->withPort($server['SERVER_PORT']);
-            }
+        if (isset($server['SERVER_NAME'])) {
+            $uri = $uri->withHost($server['SERVER_NAME']);
         }
 
         if (isset($server['HTTP_HOST'])) {
+            $uri = $uri->withHost($server['HTTP_HOST']);
+
             if (1 === \preg_match('/^(.+)\:(\d+)$/', $server['HTTP_HOST'], $matches)) {
                 $uri = $uri->withHost($matches[1])->withPort($matches[2]);
-            } else {
-                $uri = $uri->withHost($server['HTTP_HOST']);
             }
-        } elseif (isset($server['SERVER_NAME'])) {
-            $uri = $uri->withHost($server['SERVER_NAME']);
         }
 
         if (isset($server['REQUEST_URI'])) {
@@ -272,6 +260,24 @@ final class ServerRequestCreator implements ServerRequestCreatorInterface
 
         if (isset($server['QUERY_STRING'])) {
             $uri = $uri->withQuery($server['QUERY_STRING']);
+        }
+
+        if ('' !== $uri->getHost()) {
+            $uri = $uri->withScheme('http');
+
+            if (isset($server['REQUEST_SCHEME'])) {
+                $uri = $uri->withScheme($server['REQUEST_SCHEME']);
+            } elseif (isset($server['HTTPS']) && !empty($server['HTTPS'])) {
+                $uri = $uri->withScheme('https');
+            }
+
+            if (isset($server['HTTP_X_FORWARDED_PROTO'])) {
+                $uri = $uri->withScheme($server['HTTP_X_FORWARDED_PROTO']);
+            }
+        }
+
+        if (isset($server['SERVER_PORT'])) {
+            $uri = $uri->withPort($server['SERVER_PORT']);
         }
 
         return $uri;

--- a/tests/ServerRequestCreatorTest.php
+++ b/tests/ServerRequestCreatorTest.php
@@ -344,7 +344,6 @@ class ServerRequestCreatorTest extends TestCase
             'HTTP_HOST' => 'www.blakesimpson.co.uk',
             'HTTP_REFERER' => 'http://previous.url.com',
             'HTTP_USER_AGENT' => 'Mozilla/5.0 (Windows; U; Windows NT 6.0; en-GB; rv:1.9.2.6) Gecko/20100625 Firefox/3.6.6 ( .NET CLR 3.5.30729)',
-            'HTTPS' => '1',
             'REMOTE_ADDR' => '193.60.168.69',
             'REMOTE_HOST' => 'Client server\'s host name',
             'REMOTE_PORT' => '5390',
@@ -427,7 +426,6 @@ class ServerRequestCreatorTest extends TestCase
             'HTTP_HOST' => 'www.blakesimpson.co.uk',
             'HTTP_REFERER' => 'http://previous.url.com',
             'HTTP_USER_AGENT' => 'Mozilla/5.0 (Windows; U; Windows NT 6.0; en-GB; rv:1.9.2.6) Gecko/20100625 Firefox/3.6.6 ( .NET CLR 3.5.30729)',
-            'HTTPS' => '1',
             'REMOTE_ADDR' => '193.60.168.69',
             'REMOTE_HOST' => 'Client server\'s host name',
             'REMOTE_PORT' => '5390',
@@ -449,7 +447,7 @@ class ServerRequestCreatorTest extends TestCase
                 array_merge($server, ['HTTPS' => 'on', 'SERVER_PORT' => '443']),
             ],
             'Secure request via proxy' => [
-                'https://www.blakesimpson.co.uk/blog/article.php?id=10&user=foo',
+                'https://www.blakesimpson.co.uk:80/blog/article.php?id=10&user=foo',
                 array_merge($server, ['HTTP_X_FORWARDED_PROTO' => 'https', 'SERVER_PORT' => '80']),
             ],
             'HTTP_HOST missing' => [


### PR DESCRIPTION
From [php.net](https://www.php.net/manual/en/reserved.variables.server.php):

```
'HTTPS'
    Set to a non-empty value if the script was queried through the HTTPS protocol. 
```

This PR
* [x] Fix the behavior of the `HTTPS` key property.
* [x] Do not add tests
* [x] Reduce cyclomatic complexity of the of `ServerRequestCreator::createUriFromArray()` method.
