### PR TITLE
Added support for numeric headers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^7.0",
-        "nyholm/psr7": "^1.0",
+        "nyholm/psr7": "^1.3",
         "nyholm/nsa": "^1.1"
     },
     "autoload": {

--- a/src/ServerRequestCreator.php
+++ b/src/ServerRequestCreator.php
@@ -65,6 +65,11 @@ final class ServerRequestCreator implements ServerRequestCreatorInterface
 
         $serverRequest = $this->serverRequestFactory->createServerRequest($method, $uri, $server);
         foreach ($headers as $name => $value) {
+            // Because PHP automatically casts array keys set with numeric strings to integers, we have to make sure
+            // that numeric headers will not be sent along as integers, as withAddedHeader can only accept strings.
+            if (\is_int($name)) {
+                $name = (string) $name;
+            }
             $serverRequest = $serverRequest->withAddedHeader($name, $value);
         }
 

--- a/src/ServerRequestCreator.php
+++ b/src/ServerRequestCreator.php
@@ -242,6 +242,8 @@ final class ServerRequestCreator implements ServerRequestCreatorInterface
      * Create a new uri from server variable.
      *
      * @param array $server typically $_SERVER or similar structure
+     *
+     * @return UriInterface
      */
     private function createUriFromArray(array $server): UriInterface
     {

--- a/tests/ServerRequestCreatorTest.php
+++ b/tests/ServerRequestCreatorTest.php
@@ -323,6 +323,16 @@ class ServerRequestCreatorTest extends TestCase
         $this->creator->fromArrays(['REQUEST_METHOD' => 'POST'], [], [], [], [], ['test' => 'something']);
     }
 
+    public function testNumericHeaderFromHeaderArray()
+    {
+        $server = [
+            'REQUEST_METHOD' => 'GET',
+        ];
+
+        $server = $this->creator->fromArrays($server, ['1234' => 'NumericHeader']);
+        $this->assertEquals(['1234' => ['NumericHeader']], $server->getHeaders());
+    }
+
     public function testFromArrays()
     {
         $server = [
@@ -336,6 +346,8 @@ class ServerRequestCreatorTest extends TestCase
             'REQUEST_TIME' => 'Request start time: 1280149029',
             'QUERY_STRING' => 'id=10&user=foo',
             'DOCUMENT_ROOT' => '/path/to/your/server/root/',
+            'HTTP_0' => 'NumericHeaderZero',
+            'HTTP_1234' => 'NumericHeader',
             'HTTP_ACCEPT' => 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
             'HTTP_ACCEPT_CHARSET' => 'ISO-8859-1,utf-8;q=0.7,*;q=0.7',
             'HTTP_ACCEPT_ENCODING' => 'gzip,deflate',
@@ -419,6 +431,8 @@ class ServerRequestCreatorTest extends TestCase
             'REQUEST_TIME' => 'Request start time: 1280149029',
             'QUERY_STRING' => 'id=10&user=foo',
             'DOCUMENT_ROOT' => '/path/to/your/server/root/',
+            'HTTP_0' => 'NumericHeaderZero',
+            'HTTP_1234' => 'NumericHeader',
             'HTTP_ACCEPT' => 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
             'HTTP_ACCEPT_CHARSET' => 'ISO-8859-1,utf-8;q=0.7,*;q=0.7',
             'HTTP_ACCEPT_ENCODING' => 'gzip,deflate',
@@ -497,6 +511,8 @@ class ServerRequestCreatorTest extends TestCase
     public function testMarshalsExpectedHeadersFromServerArray()
     {
         $server = [
+            'HTTP_0' => 'NumericHeaderZero',
+            'HTTP_1234' => 'NumericHeader',
             'HTTP_COOKIE' => 'COOKIE',
             'HTTP_AUTHORIZATION' => 'token',
             'HTTP_CONTENT_TYPE' => 'application/json',
@@ -507,6 +523,8 @@ class ServerRequestCreatorTest extends TestCase
         ];
 
         $expected = [
+            '0' => 'NumericHeaderZero',
+            '1234' => 'NumericHeader',
             'cookie' => 'COOKIE',
             'authorization' => 'token',
             'content-type' => 'application/json',


### PR DESCRIPTION
Because this whole numeric header thing involves both psr7 and psr7-server, I think we need to make this change to keep everything in line.

https://github.com/Nyholm/psr7/pull/149 needs to be merged into psr7 first, and used in this PR for the tests to pass. I created the PR to demonstrate this.