### PR TITLE
Add PHP 8 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.php_cs.cache
+/.phpunit.result.cache
 /composer.lock
 /phpunit.xml
 /vendor/

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -5,8 +5,5 @@ finder:
         - "Resources"
         - "vendor"
 
-enabled:
-    - short_array_syntax
-
 disabled:
     - phpdoc_annotation_without_dot # This is still buggy: https://github.com/symfony/symfony/pull/19198

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ php:
     - 7.2
     - 7.3
     - 7.4
+    - nightly
 
 env:
     global:

--- a/composer.json
+++ b/composer.json
@@ -15,12 +15,12 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.1 || ^8.0",
         "psr/http-message": "^1.0",
         "psr/http-factory": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0",
+        "phpunit/phpunit": "^7.0 || ^8.5 || ^9.3",
         "nyholm/psr7": "^1.3",
         "nyholm/nsa": "^1.1"
     },

--- a/tests/ServerRequestCreatorTest.php
+++ b/tests/ServerRequestCreatorTest.php
@@ -33,13 +33,13 @@ class ServerRequestCreatorTest extends TestCase
         }
     }
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
         self::initFiles();
     }
 
-    protected function setUp()/* The :void return type declaration that should be here would cause a BC issue */
+    protected function setUp(): void
     {
         parent::setUp();
         $psr17Factory = new \Nyholm\Psr7\Factory\Psr17Factory();


### PR DESCRIPTION
I'm not sure if there any specific guidelines for this. This PR passes all the tests on PHP 7.1, 7.2, 7.4 and 8.0 RC3.

_Edit:_ I'm trying to add 8.0 to the CI pipeline using the `nightly` tag, but I'm not familiarized enough with Travis CI to choose the best way to do that. I would appreciate some guidance if that is not the best solution for now :)