### PR TITLE
Rename Zend packages / namespaces to Laminas

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,4 +35,4 @@ $serverRequest = $creator->fromGlobals();
 ## Other packages
 
 * [nyholm/psr7](https://github.com/Nyholm/psr7) - A super fast PSR-7 implementation.
-* [zendframework/zend-httphandlerrunner](https://github.com/zendframework/zend-httphandlerrunner) - To send/emit PSR-7 responses
+* [laminas/laminas-httphandlerrunner](https://github.com/laminas/laminas-httphandlerrunner) - To send/emit PSR-7 responses

--- a/src/ServerRequestCreator.php
+++ b/src/ServerRequestCreator.php
@@ -113,7 +113,7 @@ final class ServerRequestCreator implements ServerRequestCreatorInterface
     }
 
     /**
-     * Implementation from Zend\Diactoros\marshalHeadersFromSapi().
+     * Implementation from Laminas\Diactoros\marshalHeadersFromSapi().
      */
     public static function getHeadersFromServer(array $server): array
     {

--- a/tests/ServerRequestCreatorTest.php
+++ b/tests/ServerRequestCreatorTest.php
@@ -506,7 +506,7 @@ class ServerRequestCreatorTest extends TestCase
     }
 
     /**
-     * Test from zendframework/zend-diactoros.
+     * Test from laminas/laminas-diactoros (formerly zendframework/zend-diactoros).
      */
     public function testMarshalsExpectedHeadersFromServerArray()
     {
@@ -538,7 +538,7 @@ class ServerRequestCreatorTest extends TestCase
     }
 
     /**
-     * Test from zendframework/zend-diactoros.
+     * Test from laminas/laminas-diactoros (formerly zendframework/zend-diactoros).
      */
     public function testMarshalsVariablesPrefixedByApacheFromServerArray()
     {


### PR DESCRIPTION
Small PR to update Zend package & namespace references to the newer Laminas releases, after Zend has become the Laminas project in January 2020.

(See https://framework.zend.com/blog/2019-04-17-announcing-laminas.html for further reference)