### PR TITLE
Make sure the Host header only contains 1 host

### DIFF
--- a/tests/ServerRequestCreatorTest.php
+++ b/tests/ServerRequestCreatorTest.php
@@ -663,4 +663,14 @@ class ServerRequestCreatorTest extends TestCase
         $server = $this->creator->fromGlobals();
         $this->assertEquals(['1234' => ['NumericHeader']], $server->getHeaders());
     }
+
+    public function testHostHeader()
+    {
+        $_SERVER['HTTP_HOST'] = 'hostname.com';
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+
+        $serverRequest = $this->creator->fromGlobals();
+
+        $this->assertCount(1, $serverRequest->getHeader('Host'));
+    }
 }


### PR DESCRIPTION
Make sure the Host header always contains 1 value by always resetting the header with the first found value.

This fixes the issue of multiple hosts in the Host header field as reported: https://github.com/Nyholm/psr7-server/issues/48