### PR TITLE
Fix exception when trying to instantiate a slim/psr7 request

### DIFF
--- a/src/ServerRequestCreator.php
+++ b/src/ServerRequestCreator.php
@@ -276,7 +276,7 @@ final class ServerRequestCreator implements ServerRequestCreatorInterface
             }
 
             if (isset($server['SERVER_PORT'])) {
-                $uri = $uri->withPort($server['SERVER_PORT']);
+                $uri = $uri->withPort((int) $server['SERVER_PORT']);
             }
         }
 


### PR DESCRIPTION
The value of `$_SERVER['SERVER_PORT']` can be a string (at least it is when pairing nginx with php-fpm), and some PSR-7 implementations (such as slim/psr7) validate that the port is indeed an integer, resulting in an exception when calling `ServerRequestCreator->fromGlobals()` using their set of PSR-17 factories.

This patch should fix this edge case. Also note that the `@param` annotation of the `withPort()` method is `null|int`.