### PR TITLE
Fixed error code references in test

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true" bootstrap="vendor/autoload.php">
-    <testsuites>
-        <testsuite name="Unit tests">
-            <directory>tests/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" bootstrap="vendor/autoload.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="Unit tests">
+      <directory>tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/tests/ServerRequestCreatorTest.php
+++ b/tests/ServerRequestCreatorTest.php
@@ -63,7 +63,7 @@ class ServerRequestCreatorTest extends TestCase
                         'name' => 'MyFile.txt',
                         'type' => 'text/plain',
                         'tmp_name' => self::$filenames[0],
-                        'error' => '0',
+                        'error' => UPLOAD_ERR_OK,
                         'size' => '123',
                     ],
                 ],
@@ -141,14 +141,14 @@ class ServerRequestCreatorTest extends TestCase
                         'name' => 'MyFile.txt',
                         'type' => 'text/plain',
                         'tmp_name' => self::$filenames[3],
-                        'error' => '0',
+                        'error' => UPLOAD_ERR_OK,
                         'size' => '123',
                     ],
                     'image_file' => [
                         'name' => '',
                         'type' => '',
                         'tmp_name' => self::$filenames[4],
-                        'error' => '4',
+                        'error' => UPLOAD_ERR_NO_FILE,
                         'size' => '0',
                     ],
                 ],
@@ -185,8 +185,8 @@ class ServerRequestCreatorTest extends TestCase
                             1 => self::$filenames[6],
                         ],
                         'error' => [
-                            0 => '0',
-                            1 => '0',
+                            0 => UPLOAD_ERR_OK,
+                            1 => UPLOAD_ERR_OK,
                         ],
                         'size' => [
                             0 => '123',
@@ -216,10 +216,10 @@ class ServerRequestCreatorTest extends TestCase
                             ],
                         ],
                         'error' => [
-                            'other' => '0',
+                            'other' => UPLOAD_ERR_OK,
                             'test' => [
-                                0 => '0',
-                                1 => '4',
+                                0 => UPLOAD_ERR_OK,
+                                1 => UPLOAD_ERR_NO_FILE,
                             ],
                         ],
                         'size' => [


### PR DESCRIPTION
I was running the tests for this package and had several tests failing.

I dug into it and discovered that the test examples provide error codes for uploaded files as string type, but they should be int types. The strict comparison introduced in version 1.0.2 didn't recognize these error codes as intended.

Changing the error codes to the proper references in the test fixed the test cases that were failing.

I was puzzled that the build was passing on travis (the change causing the tests to fail was introduced in version 1.0.2). I noticed that when I ran PHPUnit locally it reported 30 tests passing, but when I checked the build log on travis, it only reported 29 passing tests. So it seems travis was ignoring the failing tests. But I couldn't see any reason why it would skip that, so I'm still sort of puzzled as to how travis ended up passing the build.

I also migrated the phpunit.xml.dist, while I was here. It was throwing a warning during tests.